### PR TITLE
Update npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,5 @@ npm install
 4. Start the server. It will listen on the chosen port defined in your .env file.
 
 ```sh
-npm start
+npm start-dev
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "start": "env-cmd node main.js",
+    "start": "node main.js",
+    "start-dev": "env-cmd node main.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {


### PR DESCRIPTION
## Contexte

On veut installer toctoctoc sur CleverCloud qui utilise le script `npm start` pour lancer un serveur node. Sur CleverCloud, on passe les variables d'environnement directement via leur interface sans tutiliser de fichier `.env`.

## Description

On a donc besoin que la commande `npm start` n'utilise pas le fichier .env`. Cette PR fait ce changement. On a ajouté une nouvelle commande `npm start-dev` qui utilise `env-cmd`.